### PR TITLE
feature/refactor use context

### DIFF
--- a/applications/src/components/atoms/Header/Link/CounterLink.tsx
+++ b/applications/src/components/atoms/Header/Link/CounterLink.tsx
@@ -1,6 +1,6 @@
 import { Link } from "react-router-dom";
 
-export const CounterLink = () => (
+export const CounterLink = (): JSX.Element => (
   <p>
     <Link to="/counter">Counter</Link>
   </p>

--- a/applications/src/components/atoms/Header/Link/HomeLink.tsx
+++ b/applications/src/components/atoms/Header/Link/HomeLink.tsx
@@ -1,6 +1,6 @@
 import { Link } from "react-router-dom";
 
-export const HomeLink = () => (
+export const HomeLink = (): JSX.Element => (
   <p>
     <Link to="/">Home</Link>
   </p>

--- a/applications/src/components/atoms/Header/Link/TodoListLink.tsx
+++ b/applications/src/components/atoms/Header/Link/TodoListLink.tsx
@@ -1,6 +1,6 @@
 import { Link } from "react-router-dom";
 
-export const TodoListLink = () => (
+export const TodoListLink = (): JSX.Element => (
   <p>
     <Link to="/todolist">TodoList</Link>
   </p>

--- a/applications/src/components/atoms/Header/Title/HeaderTitle.tsx
+++ b/applications/src/components/atoms/Header/Title/HeaderTitle.tsx
@@ -1,1 +1,1 @@
-export const HeaderTitle = () => <h1>React Applications Menu</h1>;
+export const HeaderTitle = (): JSX.Element => <h1>React Applications Menu</h1>;

--- a/applications/src/components/atoms/Main/Counter/Button/DecrementButton.tsx
+++ b/applications/src/components/atoms/Main/Counter/Button/DecrementButton.tsx
@@ -1,12 +1,8 @@
-export type decrementButtonProps = {
-  count: number;
-  handleDecrement: () => void;
-};
+import { useContext } from "react";
+import { CountContext } from "../../../../templates/Counter";
 
-export const DecrementButton = ({
-  count,
-  handleDecrement,
-}: decrementButtonProps): JSX.Element => {
+export const DecrementButton = (): JSX.Element => {
+  const { count, handleDecrement } = useContext(CountContext);
   return (
     <button onClick={handleDecrement} disabled={count <= 0}>
       Decrement

--- a/applications/src/components/atoms/Main/Counter/Button/IncrementButton.tsx
+++ b/applications/src/components/atoms/Main/Counter/Button/IncrementButton.tsx
@@ -1,9 +1,8 @@
-export type IncrementButtonProps = {
-  handleIncrement: () => void;
-};
+import { useContext } from "react";
+import { CountContext } from "../../../../templates/Counter";
 
-export const IncrementButton = ({
-  handleIncrement,
-}: IncrementButtonProps): JSX.Element => {
+export const IncrementButton = (): JSX.Element => {
+  const { handleIncrement } = useContext(CountContext);
+
   return <button onClick={handleIncrement}>Increment</button>;
 };

--- a/applications/src/components/atoms/Main/Counter/Button/ResetButton.tsx
+++ b/applications/src/components/atoms/Main/Counter/Button/ResetButton.tsx
@@ -1,12 +1,8 @@
-export type ResetButtonProps = {
-  count: number;
-  handleReset: () => void;
-};
+import { useContext } from "react";
+import { CountContext } from "../../../../templates/Counter";
 
-export const ResetButton = ({
-  handleReset,
-  count,
-}: ResetButtonProps): JSX.Element => {
+export const ResetButton = (): JSX.Element => {
+  const { count, handleReset } = useContext(CountContext);
   return (
     <button onClick={handleReset} disabled={count <= 0}>
       Reset

--- a/applications/src/components/atoms/Main/Counter/Count/DisplayCount.tsx
+++ b/applications/src/components/atoms/Main/Counter/Count/DisplayCount.tsx
@@ -1,7 +1,8 @@
-export type CountProps = {
-  count: number;
-};
+import { useContext } from "react";
+import { CountContext } from "../../../../templates/Counter";
 
-export const DisplayCount = ({ count }: CountProps): JSX.Element => (
-  <p>{count}</p>
-);
+export const DisplayCount = (): JSX.Element => {
+  const { count } = useContext(CountContext);
+
+  return <p>{count}</p>;
+};

--- a/applications/src/components/atoms/Main/Counter/Title/CounterTitle.tsx
+++ b/applications/src/components/atoms/Main/Counter/Title/CounterTitle.tsx
@@ -1,1 +1,1 @@
-export const CounterTitle = () => <p>Welcome To Counter App</p>;
+export const CounterTitle = (): JSX.Element => <p>Welcome To Counter App</p>;

--- a/applications/src/components/molecules/Main/Counter/Buttons.tsx
+++ b/applications/src/components/molecules/Main/Counter/Buttons.tsx
@@ -1,31 +1,13 @@
-import {
-  DecrementButton,
-  decrementButtonProps,
-} from "../../../atoms/Main/Counter/Button/DecrementButton";
-import {
-  IncrementButton,
-  IncrementButtonProps,
-} from "../../../atoms/Main/Counter/Button/IncrementButton";
-import {
-  ResetButton,
-  ResetButtonProps,
-} from "../../../atoms/Main/Counter/Button/ResetButton";
+import { DecrementButton } from "../../../atoms/Main/Counter/Button/DecrementButton";
+import { IncrementButton } from "../../../atoms/Main/Counter/Button/IncrementButton";
+import { ResetButton } from "../../../atoms/Main/Counter/Button/ResetButton";
 
-export type ButtonsProps = IncrementButtonProps &
-  decrementButtonProps &
-  ResetButtonProps;
-
-export const Buttons = ({
-  count,
-  handleIncrement,
-  handleDecrement,
-  handleReset,
-}: ButtonsProps): JSX.Element => {
+export const Buttons = (): JSX.Element => {
   return (
     <>
-      <IncrementButton handleIncrement={handleIncrement} />
-      <DecrementButton count={count} handleDecrement={handleDecrement} />
-      <ResetButton count={count} handleReset={handleReset} />
+      <IncrementButton />
+      <DecrementButton />
+      <ResetButton />
     </>
   );
 };

--- a/applications/src/components/organisms/Header/HeaderItems.tsx
+++ b/applications/src/components/organisms/Header/HeaderItems.tsx
@@ -1,7 +1,7 @@
 import { HeaderTitle } from "../../atoms/Header/Title/HeaderTitle";
 import { Links } from "../../molecules/Header/Links";
 
-export const HeaderItems = () => {
+export const HeaderItems = (): JSX.Element => {
   return (
     <>
       <HeaderTitle />

--- a/applications/src/components/organisms/Main/Counter/Counter.tsx
+++ b/applications/src/components/organisms/Main/Counter/Counter.tsx
@@ -1,28 +1,13 @@
-import {
-  CountProps,
-  DisplayCount,
-} from "../../../atoms/Main/Counter/Count/DisplayCount";
+import { DisplayCount } from "../../../atoms/Main/Counter/Count/DisplayCount";
 import { CounterTitle } from "../../../atoms/Main/Counter/Title/CounterTitle";
-import { Buttons, ButtonsProps } from "../../../molecules/Main/Counter/Buttons";
+import { Buttons } from "../../../molecules/Main/Counter/Buttons";
 
-type CounterProps = ButtonsProps & CountProps;
-
-export const Counter = ({
-  count,
-  handleIncrement,
-  handleDecrement,
-  handleReset,
-}: CounterProps): JSX.Element => {
+export const Counter = (): JSX.Element => {
   return (
     <>
       <CounterTitle />
-      <Buttons
-        count={count}
-        handleIncrement={handleIncrement}
-        handleDecrement={handleDecrement}
-        handleReset={handleReset}
-      />
-      <DisplayCount count={count} />
+      <Buttons />
+      <DisplayCount />
     </>
   );
 };

--- a/applications/src/components/templates/Counter/index.test.tsx
+++ b/applications/src/components/templates/Counter/index.test.tsx
@@ -1,6 +1,7 @@
 import { render, RenderResult } from "@testing-library/react";
 import { CounterTemplate } from ".";
 import "@testing-library/jest-dom";
+import { BrowserRouter } from "react-router-dom";
 
 let counter: RenderResult;
 
@@ -10,19 +11,31 @@ describe("Counter component test", () => {
   });
 
   test("p tag view test", async () => {
-    counter = await render(<CounterTemplate />);
+    counter = await render(
+      <BrowserRouter>
+        <CounterTemplate />
+      </BrowserRouter>
+    );
 
     expect(counter.getByText("Welcome To Counter App")).toBeDefined();
   });
 
   test("Increment button view test", async () => {
-    counter = await render(<CounterTemplate />);
+    counter = await render(
+      <BrowserRouter>
+        <CounterTemplate />
+      </BrowserRouter>
+    );
 
     expect(counter.getByText("Increment")).toBeDefined();
   });
 
   test("Increment button click test", async () => {
-    counter = await render(<CounterTemplate />);
+    counter = await render(
+      <BrowserRouter>
+        <CounterTemplate />
+      </BrowserRouter>
+    );
     const button = await counter.getByText("Increment");
     await button.click();
 
@@ -30,13 +43,21 @@ describe("Counter component test", () => {
   });
 
   test("Decrement button view test", async () => {
-    counter = await render(<CounterTemplate />);
+    counter = await render(
+      <BrowserRouter>
+        <CounterTemplate />
+      </BrowserRouter>
+    );
 
     expect(counter.getByText("Decrement")).toBeDefined();
   });
 
   test("Decrement button click test", async () => {
-    counter = await render(<CounterTemplate />);
+    counter = await render(
+      <BrowserRouter>
+        <CounterTemplate />
+      </BrowserRouter>
+    );
     const incrementButton = await counter.getByText("Increment");
     await incrementButton.click();
     const decrementButton = await counter.getByText("Decrement");
@@ -46,7 +67,11 @@ describe("Counter component test", () => {
   });
 
   test("If the number is negative, the decrement button cannot be pressed.", async () => {
-    counter = await render(<CounterTemplate />);
+    counter = await render(
+      <BrowserRouter>
+        <CounterTemplate />
+      </BrowserRouter>
+    );
     const decrementButton = await counter.getByText("Decrement");
     await decrementButton.click();
 
@@ -54,7 +79,11 @@ describe("Counter component test", () => {
   });
 
   test("If 0, the decrement button cannot be pressed", async () => {
-    counter = await render(<CounterTemplate />);
+    counter = await render(
+      <BrowserRouter>
+        <CounterTemplate />
+      </BrowserRouter>
+    );
     const decrementButton = await counter.getByRole("button", {
       name: "Decrement",
     });
@@ -63,13 +92,21 @@ describe("Counter component test", () => {
   });
 
   test("Reset button view test", async () => {
-    counter = await render(<CounterTemplate />);
+    counter = await render(
+      <BrowserRouter>
+        <CounterTemplate />
+      </BrowserRouter>
+    );
 
     expect(counter.getByText("Reset")).toBeDefined();
   });
 
   test("Reset button click test", async () => {
-    counter = await render(<CounterTemplate />);
+    counter = await render(
+      <BrowserRouter>
+        <CounterTemplate />
+      </BrowserRouter>
+    );
     const incrementButton = await counter.getByText("Increment");
     await incrementButton.click();
     const resetButton = await counter.getByText("Reset");
@@ -79,7 +116,11 @@ describe("Counter component test", () => {
   });
 
   test("If 0, the reset button cannot be pressed", async () => {
-    counter = await render(<CounterTemplate />);
+    counter = await render(
+      <BrowserRouter>
+        <CounterTemplate />
+      </BrowserRouter>
+    );
     const resetButton = await counter.getByRole("button", { name: "Reset" });
 
     expect(resetButton).toBeDisabled();

--- a/applications/src/components/templates/Counter/index.tsx
+++ b/applications/src/components/templates/Counter/index.tsx
@@ -1,8 +1,20 @@
 /** @jsxImportSource @emotion/react */
 import { css } from "@emotion/react";
-import { useState } from "react";
+import { createContext, useState } from "react";
 import { Counter } from "../../organisms/Main/Counter/Counter";
 import { HeaderItems } from "../../organisms/Header/HeaderItems";
+
+type CountContextType = {
+  count: number;
+  setCount: (count: number) => void;
+  handleIncrement: () => void;
+  handleDecrement: () => void;
+  handleReset: () => void;
+};
+
+export const CountContext = createContext<CountContextType>(
+  {} as CountContextType
+);
 
 export const CounterTemplate = (): JSX.Element => {
   const [count, setCount] = useState(0);
@@ -68,12 +80,17 @@ export const CounterTemplate = (): JSX.Element => {
     <>
       <HeaderItems />
       <div css={[button, p]}>
-        <Counter
-          count={count}
-          handleIncrement={handleIncrement}
-          handleDecrement={handleDecrement}
-          handleReset={handleReset}
-        />
+        <CountContext.Provider
+          value={{
+            count,
+            setCount,
+            handleIncrement,
+            handleDecrement,
+            handleReset,
+          }}
+        >
+          <Counter />
+        </CountContext.Provider>
       </div>
     </>
   );


### PR DESCRIPTION
- fix: useContextエラーになるためBrowserRouterでCounterTemplateをラップ
- add: 返り値の型を追加
- refactor: propsのバケツリレーを解消するためにuseContextを実装した
- refactor: useContextを使うことで不要な引数はすべて削除した
- refactor: useContextを使って引数が必要なtemplateに直接引数を渡すようにした
